### PR TITLE
Unit test for bitset::reset() function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(${TEST_NAME} 
   tests/main.test.cpp
-  tests/bitset.test.cpp)
+  tests/bitset.test.cpp
+  tests/bitreset.test.cpp)
 enable_testing()
 add_test(NAME ${TEST_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
   COMMAND ${TEST_NAME})

--- a/tests/bitreset.test.cpp
+++ b/tests/bitreset.test.cpp
@@ -1,0 +1,63 @@
+#include <boost/ut.hpp>
+#include <cstdint>
+#include <libxbitset/bitset.hpp>
+
+namespace xstd {
+boost::ut::suite bitreset_test = [](){
+    using namespace boost::ut;
+
+    "bitset::reset() increment position (0)"_test = [](){
+        xstd::bitset test_set(0); 
+        expect(that % 0x0000'0000 == test_set.reset(0)); 
+        expect(that % 0x0000'0000 == test_set.reset(1));
+        expect(that % 0x0000'0000 == test_set.reset(2));
+    };
+
+    "bitset::reset() increment position (1)"_test = [](){
+        xstd::bitset test_set(1); 
+        expect(that % 0x0000'0000 == test_set.reset(0)); 
+        expect(that % 0x0000'0000 == test_set.reset(1));
+        expect(that % 0x0000'0000 == test_set.reset(2));
+    };
+
+    "bitset::reset() increment position (2)"_test = [](){
+        xstd::bitset test_set(2);
+        expect(that % 0x0000'0002 == test_set.reset(0));
+        expect(that % 0x0000'0000 == test_set.reset(1));
+        expect(that % 0x0000'0000 == test_set.reset(2));
+    };
+
+    "bitset::reset() increment position (10)"_test = [](){
+        xstd::bitset test_set(0xA);
+        expect(that % 0x0000'000A == test_set.reset(0));
+        expect(that % 0x0000'0008 == test_set.reset(1));
+        expect(that % 0x0000'0008 == test_set.reset(2));
+    };
+
+    "bitset::reset() increment position upper half (0x1'FFFF)"_test = [](){
+        xstd::bitset test_set(0x1'FFFF);
+        expect(that % 0x0000'FFFF == test_set.reset(16));
+        expect(that % 0x0000'FFFF == test_set.reset(17));
+        expect(that % 0x0000'FFFF == test_set.reset(18));
+    };
+
+    "bitset::reset() increment position lower half full (0xFFFF'FFFF)"_test = [](){
+        xstd::bitset test_set(0xFFFF'FFFF);
+        expect(that % 0xFFFF'FFFE == test_set.reset(0));
+        expect(that % 0xFFFF'FFFC == test_set.reset(1));
+        expect(that % 0xFFFF'FFF8 == test_set.reset(2));
+    };
+
+    "bitset::reset() increment position upper half full (0xFFFF'FFFF)"_test = [](){
+        xstd::bitset test_set(0xFFFF'FFFF);
+        expect(that % 0xFFFE'FFFF == test_set.reset(16));
+        expect(that % 0xFFFC'FFFF == test_set.reset(17));
+        expect(that % 0xFFF8'FFFF == test_set.reset(18));
+    };
+
+    "bitset::reset() set out of range"_test = [](){
+        xstd::bitset test_set(0);
+        expect(throws<std::out_of_range>([&test_set](){test_set.reset(32);}));
+    };
+};
+}


### PR DESCRIPTION
I implemented a unit test for bitset::reset() that creates bitset objects with different initial values and resets the specified bit position back to 0. The test ensures that the proper value is returned when a specific bit is reset. Resolves #11